### PR TITLE
The root element returned from `viewForItem` needs to be an `li`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ subclasses. Called when the item is about to appended to the list view.
 * `item` The model item being rendered. This will always be one of the items
   previously passed to `::setItems`.
 
-Returns a String of HTML, DOM element, jQuery object, or View.
+Returns a String of HTML, DOM element, jQuery object, or View. Note the root element must be an `li`.
 
 #### `::confirmed`
 


### PR DESCRIPTION
See code in `populateList`. It has `this.list.find('li:first')`