### PR TITLE
Don't close the modal unless Atom has focus

### DIFF
--- a/src/select-list-view.coffee
+++ b/src/select-list-view.coffee
@@ -34,7 +34,7 @@ class SelectListView extends View
       @schedulePopulateList()
 
     @filterEditorView.on 'blur', (e) =>
-      @cancel() unless @cancelling or not atom.isFocused()
+      @cancel() unless @cancelling or not document.hasFocus()
 
     atom.commands.add @element,
       'core:move-up': (event) =>

--- a/src/select-list-view.coffee
+++ b/src/select-list-view.coffee
@@ -34,7 +34,7 @@ class SelectListView extends View
       @schedulePopulateList()
 
     @filterEditorView.on 'blur', (e) =>
-      @cancel() unless @cancelling
+      @cancel() unless @cancelling or not atom.isFocused()
 
     atom.commands.add @element,
       'core:move-up': (event) =>


### PR DESCRIPTION
See atom/atom#1918 for context. Now switching windows or activating the dev tools will not cause the modal panel (Command Palette, Fuzzy Finder, etc.) to disappear.