### PR TITLE
Fix scrolling performance issues in list-groups

### DIFF
--- a/stylesheets/select-list.less
+++ b/stylesheets/select-list.less
@@ -25,6 +25,7 @@
     max-height: 312px;
     margin: @component-padding 0 0 0;
     padding: 0;
+    will-change: transform;
 
     li {
       display: block;


### PR DESCRIPTION
Part of fix for atom/atom#12949.

Forces Chromium to use the compositor to render scroll containers. This greatly decreases CPU usage when scrolling.

ol.list-group also applies to the fuzzy finder and a few other things.